### PR TITLE
Add default port for web

### DIFF
--- a/src/main/kotlin/application.kt
+++ b/src/main/kotlin/application.kt
@@ -4,7 +4,9 @@ import spark.Spark.*
 import spark.SparkBase.port
 
 fun main(args: Array<String>) {
-  port(Integer.parseInt(System.getenv().get("PORT")))
+  val sysPort: String = System.getenv().get("PORT") ?: "4567"
+
+  port(Integer.parseInt(sysPort))
 
   get("/", { req, res -> "Hello World!" })
 }


### PR DESCRIPTION
Add a default port for the web branch to prevent crashes when running without a `PORT` environment variable. Also uses the awesome Elvis operator.